### PR TITLE
update code to deprecations in Atom > v1.13.0

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+.DS_Store
+npm-debug.log
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,18 +1,51 @@
 {
-  "name": "dun-syntax",
-  "theme": "syntax",
-  "author": "Claudio d'Angelis <claudiodangelis@gmail.com>",
-  "version": "0.4.0",
+  "_from": "https://www.atom.io/api/packages/dun-syntax/versions/0.4.0/tarball",
+  "_id": "dun-syntax@0.4.0",
+  "_inBundle": false,
+  "_integrity": "sha512-xTXmUpdzjDnCikxPhUWBI6ZYxjsmJOxMX6aPtIYScqyWMczwv47xnoLeLZLlfWRDMUXOl5Vqy+kwVF+HIhcS3g==",
+  "_location": "/dun-syntax",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "remote",
+    "raw": "https://www.atom.io/api/packages/dun-syntax/versions/0.4.0/tarball",
+    "rawSpec": "https://www.atom.io/api/packages/dun-syntax/versions/0.4.0/tarball",
+    "saveSpec": "https://www.atom.io/api/packages/dun-syntax/versions/0.4.0/tarball",
+    "fetchSpec": "https://www.atom.io/api/packages/dun-syntax/versions/0.4.0/tarball"
+  },
+  "_requiredBy": [
+    "#USER",
+    "/"
+  ],
+  "_resolved": "https://www.atom.io/api/packages/dun-syntax/versions/0.4.0/tarball",
+  "_shasum": "16acdfde6028af43fa811fa535687ce265b625fc",
+  "_spec": "https://www.atom.io/api/packages/dun-syntax/versions/0.4.0/tarball",
+  "_where": "/tmp/apm-install-dir-119427-16490-z3a5cx.67yx",
+  "author": {
+    "name": "Claudio d'Angelis",
+    "email": "claudiodangelis@gmail.com"
+  },
+  "bugs": {
+    "url": "https://github.com/claudiodangelis/dun-syntax/issues"
+  },
+  "bundleDependencies": false,
+  "deprecated": false,
   "description": "A greyscale syntax theme.",
+  "engines": {
+    "atom": ">=1.0.0 <2.0.0"
+  },
+  "homepage": "https://github.com/claudiodangelis/dun-syntax#readme",
   "keywords": [
     "syntax",
     "theme",
     "greyscale",
     "grayscale"
   ],
-  "repository": "https://github.com/claudiodangelis/dun-syntax",
   "license": "MIT",
-  "engines": {
-    "atom": ">=1.0.0 <2.0.0"
-  }
+  "name": "dun-syntax",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/claudiodangelis/dun-syntax.git"
+  },
+  "theme": "syntax",
+  "version": "0.4.0"
 }

--- a/styles/base.less
+++ b/styles/base.less
@@ -1,325 +1,325 @@
 @import "syntax-variables";
 
-:host,
+atom-text-editor,
 atom-text-editor {
     background-color: @syntax-background-color;
     color: @syntax-text-color;
 
-    .cursor-line {
+    .syntax--cursor-line {
         background-color: ligthen(@very-dark-gray, 40%);
     }
 
-    .wrap-guide {
+    .syntax--wrap-guide {
         background-color: @syntax-wrap-guide-color;
     }
 
-    .indent-guide {
+    .syntax--indent-guide {
         color: @syntax-indent-guide-color;
     }
 
-    .invisible-character {
+    .syntax--invisible-character {
         color: @syntax-invisible-character-color;
     }
 
-    .gutter {
+    .syntax--gutter {
         background-color: @syntax-gutter-background-color;
         color: @syntax-gutter-text-color;
 
-        .line-number {
-            &.cursor-line {
+        .syntax--line-number {
+            &.syntax--cursor-line {
                 background-color: @syntax-gutter-background-color-selected;
                 color: @syntax-gutter-text-color-selected;
             }
 
-            &.cursor-line-no-selection {
+            &.syntax--cursor-line-no-selection {
                 color: @syntax-gutter-text-color-selected;
             }
         }
     }
 
-    .fold-marker:after,
-    .gutter .line-number.folded,
-    .gutter .line-number:after {
+    .syntax--fold-marker:after,
+    .syntax--gutter .syntax--line-number.syntax--folded,
+    .syntax--gutter .syntax--line-number:after {
         color: @dark-gray;
     }
 
-    .invisible {
+    .syntax--invisible {
         color: @syntax-text-color;
     }
 
-    .cursor {
+    .syntax--cursor {
         color: @syntax-cursor-color;
     }
 
-    .selection .region {
+    .syntax--selection .syntax--region {
         background-color: @syntax-selection-color;
     }
 }
 
-:host .search-results .marker .region,
-atom-text-editor .search-results .marker .region {
+atom-text-editor .syntax--search-results .syntax--marker .syntax--region,
+atom-text-editor .syntax--search-results .syntax--marker .syntax--region {
     background-color: transparent;
     border: 1px solid @syntax-result-marker-color;
 }
 
-:host .search-results .marker.current-result .region,
-atom-text-editor .search-results .marker.current-result .region {
+atom-text-editor .syntax--search-results .syntax--marker.syntax--current-result .syntax--region,
+atom-text-editor .syntax--search-results .syntax--marker.syntax--current-result .syntax--region {
     border: 1px solid @syntax-result-marker-color-selected;
 }
 
-.comment {
+.syntax--comment {
     color: lighten(@gray, 10%);
 
-    .selection {
+    .syntax--selection {
         color: white;
     }
 }
 
-.keyword {
+.syntax--keyword {
     color: @very-light-gray;
     font-weight: bold;
 
-    &.control {
+    &.syntax--control {
         color: @very-light-gray;
     }
 
-    &.operator {
+    &.syntax--operator {
         color: @syntax-text-color;
         font-weight: bold;
     }
 
-    &.other.special-method {
+    &.syntax--other.syntax--special-method {
         color: @light-gray;
     }
 
-    &.other.unit {
+    &.syntax--other.syntax--unit {
         color: @dark-gray;
     }
 }
 
-.storage {
+.syntax--storage {
     color: @very-light-gray;
     font-weight: bold;
 }
 
-.constant {
+.syntax--constant {
     color: @light-gray;
     font-style: italic;
 
-    &.character.escape {
+    &.syntax--character.syntax--escape {
         color: @light-gray;
         font-style: italic;
     }
 
-    &.numeric {
+    &.syntax--numeric {
         color: @very-light-gray;
     }
 
-    &.other.color {
+    &.syntax--other.syntax--color {
         color: @light-gray;
     }
 
-    &.other.symbol {
+    &.syntax--other.syntax--symbol {
         color: @dark-gray;
     }
 }
 
-.variable {
+.syntax--variable {
     color: @light-gray;
 
-    &.interpolation {
+    &.syntax--interpolation {
         color: lighten(@light-gray, 10%);
     }
 
-    &.parameter.function {
+    &.syntax--parameter.syntax--function {
         color: @syntax-text-color;
         font-style: italic;
     }
 }
 
-.invalid.illegal {
+.syntax--invalid.syntax--illegal {
     background-color: @light-gray;
     color: @syntax-background-color;
 }
 
-.string {
+.syntax--string {
     color: lighten(@very-light-gray, 40%);
     background-color: @dark-gray;
 
-    &.regexp {
+    &.syntax--regexp {
         color: lighten(@very-light-gray, 40%);
         background-color: @dark-gray;
 
-        .source.ruby.embedded {
+        .syntax--source.syntax--ruby.syntax--embedded {
             color: @gray;
         }
     }
 
-    &.other.link {
+    &.syntax--other.syntax--link {
         color: @gray;
     }
 }
 
-.punctuation {
-    &.definition {
-        &.comment {
+.syntax--punctuation {
+    &.syntax--definition {
+        &.syntax--comment {
             color: lighten(@gray, 10%);
         }
 
-        &.array,
-        &.parameters,
-        &.string,
-        &.variable {
+        &.syntax--array,
+        &.syntax--parameters,
+        &.syntax--string,
+        &.syntax--variable {
             color: @syntax-text-color;
         }
 
-        &.heading,
-        &.identity {
+        &.syntax--heading,
+        &.syntax--identity {
             color: @light-gray;
         }
 
-        &.bold {
+        &.syntax--bold {
             color: @dark-gray;
             font-weight: bold;
         }
 
-        &.italic {
+        &.syntax--italic {
             color: @very-light-gray;
             font-style: italic;
         }
     }
 
-    &.section.embedded {
+    &.syntax--section.syntax--embedded {
         color: lighten(@light-gray, 10%);
     }
 }
 
-.support {
-    &.class {
+.syntax--support {
+    &.syntax--class {
         color: @light-gray;
     }
 
-    &.function {
+    &.syntax--function {
         color: @light-gray;
         font-style: italic;
 
-        &.any-method {
+        &.syntax--any-method {
             color: @light-gray;
         }
     }
 }
 
-.entity {
-    &.name.function {
+.syntax--entity {
+    &.syntax--name.syntax--function {
         color: @light-gray;
     }
 
-    &.name.type {
+    &.syntax--name.syntax--type {
         color: @light-gray;
     }
 
-    &.other.inherited-class {
+    &.syntax--other.syntax--inherited-class {
         color: @light-gray;
     }
 
-    &.name.class,
-    &.name.type.class {
+    &.syntax--name.syntax--class,
+    &.syntax--name.syntax--type.syntax--class {
         color: @light-gray;
     }
 
-    &.name.section {
+    &.syntax--name.syntax--section {
         color: @light-gray;
     }
 
-    &.name.tag {
+    &.syntax--name.syntax--tag {
         color: @light-gray;
     }
 
-    &.other.attribute-name {
+    &.syntax--other.syntax--attribute-name {
         color: @light-gray;
 
-        &.id {
+        &.syntax--id {
             color: @light-gray;
         }
     }
 }
 
-.meta {
-    &.class {
+.syntax--meta {
+    &.syntax--class {
         color: @light-gray;
     }
 
-    &.link {
+    &.syntax--link {
         color: @light-gray;
     }
 
-    &.require {
+    &.syntax--require {
         color: @light-gray;
     }
 
-    &.selector {
+    &.syntax--selector {
         color: @very-light-gray;
     }
 
-    &.separator {
+    &.syntax--separator {
         background-color: @gray;
         color: @syntax-text-color;
     }
 }
 
-.none {
+.syntax--none {
     color: @syntax-text-color;
 }
 
-.markup {
-    &.bold {
+.syntax--markup {
+    &.syntax--bold {
         color: @light-gray;
         font-weight: bold;
     }
 
-    &.changed {
+    &.syntax--changed {
         color: @very-light-gray;
     }
 
-    &.deleted {
+    &.syntax--deleted {
         color: @light-gray;
     }
 
-    &.italic {
+    &.syntax--italic {
         color: @very-light-gray;
         font-style: italic;
     }
 
-    &.heading .punctuation.definition.heading {
+    &.syntax--heading .syntax--punctuation.syntax--definition.syntax--heading {
         color: @light-gray;
     }
 
-    &.inserted {
+    &.syntax--inserted {
         color: @dark-gray;
     }
 
-    &.list {
+    &.syntax--list {
         color: @light-gray;
     }
 
-    &.quote {
+    &.syntax--quote {
         color: @dark-gray;
     }
 
-    &.raw.inline {
+    &.syntax--raw.syntax--inline {
         color: @dark-gray;
     }
 }
 
-.source.gfm .markup {
+.syntax--source.syntax--gfm .syntax--markup {
     -webkit-font-smoothing: auto;
 
-    &.heading {
+    &.syntax--heading {
         color: @light-gray;
     }
 }
 
-:host([mini]) .scroll-view,
-atom-text-editor[mini] .scroll-view {
+atom-text-editor[mini] .syntax--scroll-view,
+atom-text-editor[mini] .syntax--scroll-view {
     padding-left: 1px;
 }

--- a/styles/base.less
+++ b/styles/base.less
@@ -1,6 +1,5 @@
 @import "syntax-variables";
 
-atom-text-editor,
 atom-text-editor {
     background-color: @syntax-background-color;
     color: @syntax-text-color;
@@ -56,13 +55,11 @@ atom-text-editor {
     }
 }
 
-atom-text-editor .syntax--search-results .syntax--marker .syntax--region,
 atom-text-editor .syntax--search-results .syntax--marker .syntax--region {
     background-color: transparent;
     border: 1px solid @syntax-result-marker-color;
 }
 
-atom-text-editor .syntax--search-results .syntax--marker.syntax--current-result .syntax--region,
 atom-text-editor .syntax--search-results .syntax--marker.syntax--current-result .syntax--region {
     border: 1px solid @syntax-result-marker-color-selected;
 }
@@ -319,7 +316,6 @@ atom-text-editor .syntax--search-results .syntax--marker.syntax--current-result 
     }
 }
 
-atom-text-editor[mini] .syntax--scroll-view,
 atom-text-editor[mini] .syntax--scroll-view {
     padding-left: 1px;
 }


### PR DESCRIPTION
Starting from Atom v1.13.0, the contents of atom-text-editor elements
are no longer encapsulated within a shadow DOM boundary. This means you
should stop using :host and ::shadow pseudo-selectors, and prepend all
your syntax selectors with "syntax--".